### PR TITLE
Disable controls during an exposure

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -22,7 +22,7 @@ function App() {
   const [currTemp, setCurrTemp] = useState()
   const [currStatus, setCurrStatus] = useState()
   const [displayedImage, setDisplayedImage] = useState(process.env.PUBLIC_URL + '/coma.fits')
-  const [disabledExpType, setDisabledExpType] = useState(false)
+  const [disableControls, setDisableControls] = useState(false)
 
   
   useEffect(()=>{setTimeout(()=>window.JS9.Load(displayedImage, {refresh: true}), 500)}, [displayedImage])
@@ -37,18 +37,18 @@ function App() {
     
       <PingServer/>
       <GetStatus currStatus={currStatus} setCurrStatus={setCurrStatus}/>
-      <ImageTypeSelector imageType={imageType} setImageType={setImageType}/>
-      <ExposureTypeSelector exposureType={exposureType} setExposureType={setExposureType} isDisabled={disabledExpType}/>
-      <FilterTypeSelector filterType={filterType} setFilterType={setFilterType}/>
-      <SetTemp temp={temp} setTemp={setTemp}/>
+      <ImageTypeSelector imageType={imageType} setImageType={setImageType} isDisabled={disableControls}/>
+      <ExposureTypeSelector exposureType={exposureType} setExposureType={setExposureType} isDisabled={disableControls}/>
+      <FilterTypeSelector filterType={filterType} setFilterType={setFilterType} isDisabled={disableControls}/>
+      <SetTemp temp={temp} setTemp={setTemp} isDisabled={disableControls}/>
       <GetTemp currTemp={currTemp} setCurrTemp={setCurrTemp}/>
       <ExposureControls
-        exposureType={exposureType} 
+        exposureType={exposureType}
         imageType={imageType} 
         filterType={filterType}
         temp = {temp}
         setDisplayedImage = {setDisplayedImage}
-        setDisableExpType = {setDisabledExpType}
+        setDisableControls = {setDisableControls}
       />
       <div className="display">
         <div className="JS9Menubar"></div>

--- a/src/App.js
+++ b/src/App.js
@@ -22,7 +22,7 @@ function App() {
   const [currTemp, setCurrTemp] = useState()
   const [currStatus, setCurrStatus] = useState()
   const [displayedImage, setDisplayedImage] = useState(process.env.PUBLIC_URL + '/coma.fits')
-  const [disableControls, setDisableControls] = useState(false)
+  const [_, makeUpdate] = useState()
 
   
   useEffect(()=>{setTimeout(()=>window.JS9.Load(displayedImage, {refresh: true}), 500)}, [displayedImage])
@@ -37,10 +37,10 @@ function App() {
     
       <PingServer/>
       <GetStatus currStatus={currStatus} setCurrStatus={setCurrStatus}/>
-      <ImageTypeSelector imageType={imageType} setImageType={setImageType} isDisabled={disableControls}/>
-      <ExposureTypeSelector exposureType={exposureType} setExposureType={setExposureType} isDisabled={disableControls}/>
-      <FilterTypeSelector filterType={filterType} setFilterType={setFilterType} isDisabled={disableControls}/>
-      <SetTemp temp={temp} setTemp={setTemp} isDisabled={disableControls}/>
+      <ImageTypeSelector imageType={imageType} setImageType={setImageType} isDisabled={currStatus === 20072}/>
+      <ExposureTypeSelector exposureType={exposureType} setExposureType={setExposureType} isDisabled={currStatus === 20072}/>
+      <FilterTypeSelector filterType={filterType} setFilterType={setFilterType} isDisabled={currStatus === 20072}/>
+      <SetTemp temp={temp} setTemp={setTemp} isDisabled={currStatus === 20072}/>
       <GetTemp currTemp={currTemp} setCurrTemp={setCurrTemp}/>
       <ExposureControls
         exposureType={exposureType}
@@ -48,7 +48,7 @@ function App() {
         filterType={filterType}
         temp = {temp}
         setDisplayedImage = {setDisplayedImage}
-        setDisableControls = {setDisableControls}
+        update = {makeUpdate}
       />
       <div className="display">
         <div className="JS9Menubar"></div>

--- a/src/App.js
+++ b/src/App.js
@@ -22,7 +22,7 @@ function App() {
   const [currTemp, setCurrTemp] = useState()
   const [currStatus, setCurrStatus] = useState()
   const [displayedImage, setDisplayedImage] = useState(process.env.PUBLIC_URL + '/coma.fits')
-  const [_, makeUpdate] = useState()
+  const [disableControls, setDisableControls] = useState(false)
 
   
   useEffect(()=>{setTimeout(()=>window.JS9.Load(displayedImage, {refresh: true}), 500)}, [displayedImage])
@@ -37,10 +37,10 @@ function App() {
     
       <PingServer/>
       <GetStatus currStatus={currStatus} setCurrStatus={setCurrStatus}/>
-      <ImageTypeSelector imageType={imageType} setImageType={setImageType} isDisabled={currStatus === 20072}/>
-      <ExposureTypeSelector exposureType={exposureType} setExposureType={setExposureType} isDisabled={currStatus === 20072}/>
-      <FilterTypeSelector filterType={filterType} setFilterType={setFilterType} isDisabled={currStatus === 20072}/>
-      <SetTemp temp={temp} setTemp={setTemp} isDisabled={currStatus === 20072}/>
+      <ImageTypeSelector imageType={imageType} setImageType={setImageType} isDisabled={disableControls}/>
+      <ExposureTypeSelector exposureType={exposureType} setExposureType={setExposureType} isDisabled={disableControls}/>
+      <FilterTypeSelector filterType={filterType} setFilterType={setFilterType} isDisabled={disableControls}/>
+      <SetTemp temp={temp} setTemp={setTemp} isDisabled={disableControls}/>
       <GetTemp currTemp={currTemp} setCurrTemp={setCurrTemp}/>
       <ExposureControls
         exposureType={exposureType}
@@ -48,7 +48,7 @@ function App() {
         filterType={filterType}
         temp = {temp}
         setDisplayedImage = {setDisplayedImage}
-        update = {makeUpdate}
+        setDisableControls = {setDisableControls}
       />
       <div className="display">
         <div className="JS9Menubar"></div>

--- a/src/components/ExposureControls.jsx
+++ b/src/components/ExposureControls.jsx
@@ -4,7 +4,7 @@ import {useEffect, useState} from "react"
 
 
 
-function ExposureControls({ exposureType, imageType, filterType, setDisplayedImage, update}) {
+function ExposureControls({ exposureType, imageType, filterType, setDisplayedImage, setDisableControls}) {
 
     const [playing, setPlaying] = useState(false)
     const [audio] = useState(new Audio(process.env.PUBLIC_URL + '/tadaa-47995.mp3'))
@@ -19,7 +19,7 @@ function ExposureControls({ exposureType, imageType, filterType, setDisplayedIma
 
     const onSubmit = async data => {
         if (isExposing) return
-        update(true)
+        setDisableControls(true)
         setExposureData(null)
         // if exposure time is less than 0, set it to 0
         data.exptime = exposureType === "Real Time" ? 0.3 : Math.max(0, data.exptime)
@@ -54,21 +54,17 @@ function ExposureControls({ exposureType, imageType, filterType, setDisplayedIma
         if (!exposureType === "Real Time") {
             setPlaying(true)
         }
+
+        setDisableControls(false)
         setExposureData(data)
-        update(exposureType === "Real Time")
     }
 
     // Repeat exposures in Real Time until stopped
     useEffect(() => {
         if (exposureData == null) return
-        if (exposureData.exptype === "Real Time") 
+        if (exposureData.exptype === "Real Time" && !stopRealtime) 
         {
-            if (!stopRealtime) {
-                onSubmit(exposureData);
-            }
-            else {
-                update(false)
-            }
+            onSubmit(exposureData);
         }
     }, [exposureData]
     )

--- a/src/components/ExposureControls.jsx
+++ b/src/components/ExposureControls.jsx
@@ -4,7 +4,7 @@ import {useEffect, useState} from "react"
 
 
 
-function ExposureControls({ exposureType, imageType, filterType, setDisplayedImage, setDisableExpType}) {
+function ExposureControls({ exposureType, imageType, filterType, setDisplayedImage, setDisableControls}) {
 
     const [playing, setPlaying] = useState(false)
     const [audio] = useState(new Audio(process.env.PUBLIC_URL + '/tadaa-47995.mp3'))
@@ -19,7 +19,7 @@ function ExposureControls({ exposureType, imageType, filterType, setDisplayedIma
 
     const onSubmit = async data => {
         if (isExposing) return
-        setDisableExpType(true)
+        setDisableControls(true)
         setExposureData(null)
         // if exposure time is less than 0, set it to 0
         data.exptime = exposureType === "Real Time" ? 0.3 : Math.max(0, data.exptime)
@@ -55,7 +55,7 @@ function ExposureControls({ exposureType, imageType, filterType, setDisplayedIma
             setPlaying(true)
         }
 
-        setDisableExpType(false)
+        setDisableControls(false)
         setExposureData(data)
     }
 

--- a/src/components/ExposureControls.jsx
+++ b/src/components/ExposureControls.jsx
@@ -4,7 +4,7 @@ import {useEffect, useState} from "react"
 
 
 
-function ExposureControls({ exposureType, imageType, filterType, setDisplayedImage, setDisableControls}) {
+function ExposureControls({ exposureType, imageType, filterType, setDisplayedImage, update}) {
 
     const [playing, setPlaying] = useState(false)
     const [audio] = useState(new Audio(process.env.PUBLIC_URL + '/tadaa-47995.mp3'))
@@ -19,7 +19,7 @@ function ExposureControls({ exposureType, imageType, filterType, setDisplayedIma
 
     const onSubmit = async data => {
         if (isExposing) return
-        setDisableControls(true)
+        update(true)
         setExposureData(null)
         // if exposure time is less than 0, set it to 0
         data.exptime = exposureType === "Real Time" ? 0.3 : Math.max(0, data.exptime)
@@ -54,17 +54,21 @@ function ExposureControls({ exposureType, imageType, filterType, setDisplayedIma
         if (!exposureType === "Real Time") {
             setPlaying(true)
         }
-
-        setDisableControls(false)
         setExposureData(data)
+        update(exposureType === "Real Time")
     }
 
     // Repeat exposures in Real Time until stopped
     useEffect(() => {
         if (exposureData == null) return
-        if (exposureData.exptype === "Real Time" && !stopRealtime) 
+        if (exposureData.exptype === "Real Time") 
         {
-            onSubmit(exposureData);
+            if (!stopRealtime) {
+                onSubmit(exposureData);
+            }
+            else {
+                update(false)
+            }
         }
     }, [exposureData]
     )

--- a/src/components/FilterControls.jsx
+++ b/src/components/FilterControls.jsx
@@ -6,13 +6,13 @@ import { getFilterWheel, homeFilterWheel, setFilterWheel } from '../apiClient';
 function FilterTypeSelector({ filterType, setFilterType, isDisabled }) {
   const [moving, setMoving] = useState(false);
 
-  useEffect(() => {
-    setInterval(() => {
-      getFilterWheel()
-        .then((reply) => setFilterType(reply.filter))
-        .catch((err) => console.log(err));
-    }, 1000);
-  }, [setFilterType]);
+  // useEffect(() => {
+  //   setInterval(() => {
+  //     getFilterWheel()
+  //       .then((reply) => setFilterType(reply.filter))
+  //       .catch((err) => console.log(err));
+  //   }, 1000);
+  // }, [setFilterType]);
 
   const handleFilterChange = (filter) => {
     setMoving(true);

--- a/src/components/FilterControls.jsx
+++ b/src/components/FilterControls.jsx
@@ -6,13 +6,13 @@ import { getFilterWheel, homeFilterWheel, setFilterWheel } from '../apiClient';
 function FilterTypeSelector({ filterType, setFilterType, isDisabled }) {
   const [moving, setMoving] = useState(false);
 
-  // useEffect(() => {
-  //   setInterval(() => {
-  //     getFilterWheel()
-  //       .then((reply) => setFilterType(reply.filter))
-  //       .catch((err) => console.log(err));
-  //   }, 1000);
-  // }, [setFilterType]);
+  useEffect(() => {
+    setInterval(() => {
+      getFilterWheel()
+        .then((reply) => setFilterType(reply.filter))
+        .catch((err) => console.log(err));
+    }, 1000);
+  }, [setFilterType]);
 
   const handleFilterChange = (filter) => {
     setMoving(true);

--- a/src/components/FilterControls.jsx
+++ b/src/components/FilterControls.jsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import { getFilterWheel, homeFilterWheel, setFilterWheel } from '../apiClient';
 
-function FilterTypeSelector({ filterType, setFilterType }) {
+function FilterTypeSelector({ filterType, setFilterType, isDisabled }) {
   const [moving, setMoving] = useState(false);
 
   useEffect(() => {
@@ -32,7 +32,7 @@ function FilterTypeSelector({ filterType, setFilterType }) {
   };
 
   return (
-    <fieldset disabled={moving} className="filter">
+    <fieldset disabled={(moving || isDisabled)} className="filter">
       <legend>Filters</legend>
       <label disabled>
         Home

--- a/src/components/GetStatus.jsx
+++ b/src/components/GetStatus.jsx
@@ -1,4 +1,5 @@
 import { getStatus } from "../apiClient";
+import { useEffect } from "react";
 
 function GetStatus({currStatus, setCurrStatus}) {
 
@@ -11,6 +12,12 @@ function GetStatus({currStatus, setCurrStatus}) {
     if(currStatus != null){
       statusMessage = <span className='statusMessage'>Current Status: {currStatus}</span>
     }
+
+    // get status on refresh
+    useEffect(() => {
+      callGetStatus();
+      console.log(currStatus)
+    });
 
     return (
       <fieldset className="Status">

--- a/src/components/GetStatus.jsx
+++ b/src/components/GetStatus.jsx
@@ -1,5 +1,4 @@
 import { getStatus } from "../apiClient";
-import { useEffect } from "react";
 
 function GetStatus({currStatus, setCurrStatus}) {
 
@@ -12,12 +11,6 @@ function GetStatus({currStatus, setCurrStatus}) {
     if(currStatus != null){
       statusMessage = <span className='statusMessage'>Current Status: {currStatus}</span>
     }
-
-    // get status on refresh
-    useEffect(() => {
-      callGetStatus();
-      console.log(currStatus)
-    });
 
     return (
       <fieldset className="Status">

--- a/src/components/ImageTypeSelector.jsx
+++ b/src/components/ImageTypeSelector.jsx
@@ -1,11 +1,11 @@
-function ImageTypeSelector({imageType, setImageType}) {
+function ImageTypeSelector({imageType, setImageType, isDisabled}) {
 
     function GetImageTypeClicked(e) {
         setImageType(e.target.value)
     }
     
   return (
-    <fieldset> 
+    <fieldset disabled={isDisabled}> 
         <legend>
             Image Type
         </legend>

--- a/src/components/SetTemp.jsx
+++ b/src/components/SetTemp.jsx
@@ -1,7 +1,7 @@
 import { useForm } from "react-hook-form"
 import { setTemperature } from "../apiClient";
 
-function SetTemp({temp, setTemp}) {
+function SetTemp({temp, setTemp, isDisabled}) {
 
     const {register, handleSubmit} = useForm()
 
@@ -31,9 +31,9 @@ function SetTemp({temp, setTemp}) {
       <form onSubmit={handleSubmit(onSubmit)} className='Temperature'>
         <label>Set Temperature</label>
         <span className='tempCelsiusIcon'>
-          <input type='text' {...register('temperature', { required: true })} maxLength='4' placeholder='-50'/>
+          <input type='text' {...register('temperature', { required: true })} maxLength='4' placeholder='-50' disabled={isDisabled}/>
         </span>
-        <button type='submit'>Set</button>
+        <button type='submit' disabled={isDisabled}>Set</button>
         {coolingMessage}
       </form>
       


### PR DESCRIPTION
This is client-side (from the click of the get exposure button). Should be fixed later to be server-side (using andor status codes).