### PR TITLE
Less frequent filter wheel get position requests

### DIFF
--- a/src/components/FilterControls.jsx
+++ b/src/components/FilterControls.jsx
@@ -32,7 +32,11 @@ function FilterTypeSelector({ filterType, setFilterType, isDisabled }) {
   const handleHome = () => {
     setMoving(true);
     homeFilterWheel()
-      .then(() => setMoving(false))
+      .then(() => {
+        updateFilterPosition()
+          .then(() => setMoving(false))
+          .catch((err) => console.log(err));
+      })
       .catch((err) => console.log(err));
   };
 

--- a/src/components/FilterControls.jsx
+++ b/src/components/FilterControls.jsx
@@ -1,26 +1,30 @@
 //import { setFilter } from "../apiClient";
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { getFilterWheel, homeFilterWheel, setFilterWheel } from '../apiClient';
 import BeatLoader from 'react-spinners/BeatLoader';
 
 function FilterTypeSelector({ filterType, setFilterType, isDisabled }) {
   const [moving, setMoving] = useState(false);
 
-  useEffect(() => {
-    setInterval(() => {
-      getFilterWheel()
-        .then((reply) => setFilterType(reply.filter))
-        .catch((err) => console.log(err));
-    }, 1000);
+  const updateFilterPosition = useCallback(async () => {
+    getFilterWheel()
+      .then((reply) => setFilterType(reply.filter))
+      .catch((err) => console.log(err));
   }, [setFilterType]);
+
+  useEffect(() => {
+    // Do this once when the app loads.
+    updateFilterPosition();
+  }, [updateFilterPosition]);
 
   const handleFilterChange = (filter) => {
     setMoving(true);
     setFilterWheel(filter)
       .then(() => {
-        setMoving(false);
-        setFilterType(filter);
+        updateFilterPosition()
+          .then(() => setMoving(false))
+          .catch((err) => console.log(err));
       })
       .catch((err) => console.log(err));
   };
@@ -33,7 +37,7 @@ function FilterTypeSelector({ filterType, setFilterType, isDisabled }) {
   };
 
   return (
-    <fieldset disabled={(moving || isDisabled)} className="filter">
+    <fieldset disabled={moving || isDisabled} className="filter">
       <legend>Filters</legend>
       <label>
         Ha


### PR DESCRIPTION
This PR changes the client to request the position of the filter wheel only when the webapp starts or when the filter wheel is moved or homed.