### PR TITLE
JS9 improvements

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <link type="text/css" rel="stylesheet" href="%PUBLIC_URL%/js9/js9support.css">
     <link type="text/css" rel="stylesheet" href="%PUBLIC_URL%/js9/js9.css">
-    <script type="text/javascript" src="%PUBLIC_URL%/js9/js9prefs.js"></script>
+    <script type="text/javascript" src="%PUBLIC_URL%/js9prefs.js"></script>
     <script type="text/javascript" src="%PUBLIC_URL%/js9/js9support.js"></script>
     <script type="text/javascript" src="%PUBLIC_URL%/js9/js9.js"></script>
     <script type="text/javascript" src="%PUBLIC_URL%/js9/js9plugins.js"></script>

--- a/public/js9prefs.js
+++ b/public/js9prefs.js
@@ -1,0 +1,26 @@
+var JS9Prefs = {
+  globalOpts: {
+    helperType: 'none',
+    helperPort: 2718,
+    ehretries: 0,
+    helperCGI: './cgi-bin/js9/js9Helper.cgi',
+    debug: 0,
+    loadProxy: false,
+    workDir: './tmp',
+    workDirQuota: 100,
+    dataPath: '$HOME/Desktop:$HOME/Downloads:/data/gcam',
+    analysisPlugins: './analysis-plugins',
+    analysisWrappers: './analysis-wrappers',
+    resize: false,
+    fits2fits: 'never',
+    alerts: false,
+    clearImageMemory: 'always',
+    // waitType: 'mouse',
+    useWasm: false,
+    panWithinDisplay: true,
+  },
+  imageOpts: {
+    colormap: 'heat',
+    scale: 'linear',
+  },
+};

--- a/src/App.js
+++ b/src/App.js
@@ -4,14 +4,14 @@ import { getStatus } from "./apiClient";
 import logo from './aueg_logo.png';
 import ExposureControls from './components/ExposureControls';
 import FilterTypeSelector from './components/FilterControls';
+import Focus from "./components/Focus";
+import Framing from "./components/Framing";
 import GetStatus from './components/GetStatus';
 import GetTemp from './components/GetTemp';
 import ImageTypeSelector from './components/ImageTypeSelector';
 import OnOff from './components/OnOffFunctionality';
 import ExposureTypeSelector from './components/SetExposureType';
 import SetTemp from './components/SetTemp';
-import Focus from "./components/Focus";
-import Framing from "./components/Framing";
 
 // https://github.com/ericmandel/js9
 
@@ -30,9 +30,25 @@ function App() {
   const [displayedImage, setDisplayedImage] = useState(process.env.PUBLIC_URL + '/coma.fits')
   const [disableControls, setDisableControls] = useState(false)
   const [initialized, setInitialized] = useState(getStatus()['status'] === '20073')
+  const [isLoading, setIsLoading] = useState(true)
 
-  useEffect(()=>{setTimeout(()=>window.JS9.Load(displayedImage, {refresh: true}), 2000)}, [displayedImage])
-
+  useEffect(
+    () => {
+      if (isLoading) {
+        // On page load, display the default image and set the zoom to fit (after some
+        // delays to allow JS9 to load and display on the image properly).
+        setTimeout(
+          () => {
+            window.JS9.Load(displayedImage);
+            setTimeout(() => window.JS9.SetZoom('toFit'), 1000);
+            setIsLoading(false);
+          }, 2000)
+        } else {
+          // For images captured by the camera after the initial load, refresh the 
+          // image, which preservers the current settings (e.g. zoom, pan, etc.)
+          window.JS9.RefreshImage(displayedImage);
+        }
+      }, [displayedImage, isLoading])
 
   return (
     <div className='App' >
@@ -71,7 +87,7 @@ function App() {
       </div>
     </div>
     </div>
-      
+
   );
 }
 


### PR DESCRIPTION
- Preserve zoom, scale, data limits, etc. when a new image is loaded.
- Tweak the initial settings and disable the helper (this was just silently failing when JS9 loaded, not really an issue).