### PR TITLE
Simple UI fixes for issues #56 and #57

### DIFF
--- a/public/js9/js9support.css
+++ b/public/js9/js9support.css
@@ -58,6 +58,13 @@
   src: url("font/context-menu-icons.eot?2lkho#iefix") format("embedded-opentype"), url("font/context-menu-icons.woff2?2lkho") format("woff2"), url("font/context-menu-icons.woff?2lkho") format("woff"), url("font/context-menu-icons.ttf?2lkho") format("truetype");
 }
 
+/* 3dPlot tooltip z-index fix */
+/* Only targets the tooltip if it is a direct child of body, is 200px wide, and white 
+(there was no class for the element) */
+body > div[style*="position: absolute"][style*="width: 200px"][style*="color: rgb(255, 255, 255)"] {
+    z-index: 1000 !important;
+}
+
 .context-menu-icon-add:before {
   content: "\EA01";
 }

--- a/src/App.css
+++ b/src/App.css
@@ -125,7 +125,6 @@ fieldset {
 .tempCelsiusIcon::before {
   font-size: 14px;
   font-weight: bold;
-  z-index: 999;
   position: absolute;
   top: 2px;
   left: 46px;


### PR DESCRIPTION
Fixes 2 small layering issues with the 3dPlot tooltip rendering behind the 3dPlot and the *C degrees sign rendering above everything. The changes are removing the z index attribute from the *C element and adding a band-aid fix to give the tooltip a z index above the 3dPlot. My fix for the 3dPlot tooltip is kind of messy because the text element has no id or class for some reason. closes #56 closes #57 